### PR TITLE
Add sphinx_rtd_theme_ext_color_contrast

### DIFF
--- a/content/conf.py
+++ b/content/conf.py
@@ -34,6 +34,8 @@ extensions = [
     # githubpages just adds a .nojekyll file
     'sphinx.ext.githubpages',
     'sphinx_lesson',
+    # remove once sphinx_rtd_theme updated for contrast and accessibility:
+    'sphinx_rtd_theme_ext_color_contrast',
     #'sphinx.ext.intersphinx',
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Sphinx
 sphinx_rtd_theme
+sphinx_rtd_theme_ext_color_contrast
 myst_nb
 sphinx-lesson


### PR DESCRIPTION
- Improves web accessibility for the default sphinx-lesson-template
  theme
- Review: mainly, consider in what cases this adds extra complexity:
  - Deprecation process, once this is no longer needed, is it too hard
    to ask everyone to remove it?  I think it won't be too hard, since
    we can release an update that depends on
    sphinx_rtd_theme>fixed_version and have this new version do
    nothing.
  - What if the template is used without sphinx_rtd_theme?  This has
    to be commented out.