### PR TITLE
Add parameters to checkout action

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -16,15 +16,15 @@ jobs:
     steps:
       # https://github.com/marketplace/actions/checkout
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          lfs: true
       # https://github.com/marketplace/actions/setup-python
       # ^-- This gives info on matrix testing.
       - name: Install Python
         uses: actions/setup-python@v1
         with:
           python-version: 3.8
-      - name: Fetch all refs
-        run: |
-          git fetch
       # I don't know where the "run" thing is documented.
       - name: Install dependencies
         run: |


### PR DESCRIPTION
- Fetch all branches and tags.
- Use LFS. This is helpful when using notebook content, which might get a bit large.