### PR TITLE
Add copybutton conf to exclude prompt

### DIFF
--- a/content/conf.py
+++ b/content/conf.py
@@ -50,6 +50,9 @@ myst_enable_extensions = [
     "colon_fence",
 ]
 
+# Settings for sphinx-copybutton
+copybutton_exclude = ".linenos, .gp"
+
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']
 


### PR DESCRIPTION
See https://github.com/coderefinery/sphinx-lesson/issues/93
This was added to

https://github.com/coderefinery/git-intro/blob/3ad12101848a886e2c0c2cd032ce86f943c9f9ee/content/conf.py#L51

but this change implements the fix in the template.
