### PR TITLE
Pyppeteer fixes

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -100,9 +100,9 @@ jobs:
       - name: Generate PDF
         if: ${{ env.GENERATE_PDF == 'true' }}
         run: |
-          #pip install https://github.com/rkdarst/sphinx_pyppeteer_builder/archive/refs/heads/main.zip
-          pip install sphinx_pyppeteer_builder
-          make pyppeteer
+          pip install https://github.com/rkdarst/sphinx_pyppeteer_builder/archive/refs/heads/main.zip
+          make clean
+          make SPHINXOPTS="-t pdf" pyppeteer
           mv _build/pyppeteer/*.pdf _build/dirhtml/${PDF_FILENAME}
 
       # Stage all deployed assets in _gh-pages/ for simplicity, and to


### PR DESCRIPTION
- Use the custom version of pyppeteer, which now handles group tabs
- Clean cache and use the tag "pdf" for pyppeteer
- Add the "pdf" tag to pdf builds. This instructs `sphinx_lesson` to use the pyppeteer_builder.tabs extension and imgmath